### PR TITLE
Feat/171/crossaccount access points

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # 0.3.0 (Aug 10, 2026)
-* Added `crossaccount_account_ids` to share this bucket with other AWS accounts through S3 access points.
+* Added `trusted_account_ids` to share this bucket with other AWS accounts through S3 access points.
 * The bucket policy is now created whenever any statement applies, not only for `public_read_only`. `aws_s3_bucket_policy.public_read_only` was renamed to `aws_s3_bucket_policy.this`; a `moved` block handles the state migration.
-* `public_read_only` and `crossaccount_account_ids` are mutually exclusive and now fail at apply time rather than silently at runtime.
+* `public_read_only` and `trusted_account_ids` are mutually exclusive and now fail at apply time rather than silently at runtime.
 
 # 0.2.0 (Jun 25, 2026)
 * Upgraded `ns` provider.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.2.1 (Aug 10, 2026)
+# 0.3.0 (Aug 10, 2026)
 * Added `trusted_access_points` to share this bucket with other AWS accounts through S3 access points, each granted `read` or `write`.
 * The bucket policy is now created whenever any statement applies, not only for `public_read_only`. `aws_s3_bucket_policy.public_read_only` was renamed to `aws_s3_bucket_policy.this`; a `moved` block handles the state migration.
 * `public_read_only` and `trusted_access_points` are mutually exclusive and now fail at apply time rather than silently at runtime.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,9 @@
-# 0.3.0 (Aug 10, 2026)
+# 0.2.1 (Aug 10, 2026)
 * Added `trusted_account_ids` to share this bucket with other AWS accounts through S3 access points.
 * The bucket policy is now created whenever any statement applies, not only for `public_read_only`. `aws_s3_bucket_policy.public_read_only` was renamed to `aws_s3_bucket_policy.this`; a `moved` block handles the state migration.
 * `public_read_only` and `trusted_account_ids` are mutually exclusive and now fail at apply time rather than silently at runtime.
 
-# 0.2.0 (Jun 25, 2026)
+# 0.2.0 (Aug 10, 2026)
 * Upgraded `ns` provider.
 * Switched to `aws_tags` for proper resource attribution.
 * Added `aws_account_id` to outputs.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # 0.2.1 (Aug 10, 2026)
-* Added `trusted_account_ids` to share this bucket with other AWS accounts through S3 access points.
+* Added `trusted_access_points` to share this bucket with other AWS accounts through S3 access points, each granted `read` or `write`.
 * The bucket policy is now created whenever any statement applies, not only for `public_read_only`. `aws_s3_bucket_policy.public_read_only` was renamed to `aws_s3_bucket_policy.this`; a `moved` block handles the state migration.
-* `public_read_only` and `trusted_account_ids` are mutually exclusive and now fail at apply time rather than silently at runtime.
+* `public_read_only` and `trusted_access_points` are mutually exclusive and now fail at apply time rather than silently at runtime.
 
 # 0.2.0 (Aug 10, 2026)
 * Upgraded `ns` provider.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.3.0 (Aug 10, 2026)
+* Added `crossaccount_account_ids` to share this bucket with other AWS accounts through S3 access points.
+* The bucket policy is now created whenever any statement applies, not only for `public_read_only`. `aws_s3_bucket_policy.public_read_only` was renamed to `aws_s3_bucket_policy.this`; a `moved` block handles the state migration.
+* `public_read_only` and `crossaccount_account_ids` are mutually exclusive and now fail at apply time rather than silently at runtime.
+
 # 0.2.0 (Jun 25, 2026)
 * Upgraded `ns` provider.
 * Switched to `aws_tags` for proper resource attribution.

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ save and retrieve files without having to think about persistence. For more info
 | `public_read_only`        | boolean          | `false`    | If toggled on, the contents of this S3 bucket will be made publicly accessible. Public access will be read-only.                                                                                                                                           |
 | `cors_orgins`             | list(string)     | `[]`       | A set of origins that are allowed to make GET requests to this S3 bucket.                                                                                                                                                                                  |
 | `cors_methods`            | list(string)     | `["GET"]`  | A set of HTTP verbs that are allowed to be used when making CORS requests to this S3 bucket.                                                                                                                                                               |
+| `crossaccount_account_ids` | set(string)     | `[]`       | AWS account IDs allowed to reach this bucket through an S3 access point. See [Sharing across AWS accounts](#sharing-across-aws-accounts).                                                                                                                   |
 
 ## Outputs
 | Name                      | Description                                                                    |
@@ -42,6 +43,8 @@ save and retrieve files without having to think about persistence. For more info
 | `db_hostname`             | The name of the created s3 bucket.                                             |
 | `db_port`                 | This port of the created s3 bucket (always blank).                             |
 | `db_protocol`             | URI Protocol (always `s3`)                                                     |
+| `db_region`               | The region of the created S3 bucket.                                           |
+| `aws_account_id`          | The AWS account that owns this bucket. S3 bucket ARNs contain no account ID, so consumers that need it rely on this output. |
 
 ---
 
@@ -49,3 +52,17 @@ save and retrieve files without having to think about persistence. For more info
 Connect this S3 bucket to your applications using a capability.
 The capability will set up the correct access privileges and inject the connection information into your applications via ENV variables.
 This S3 bucket can be connected to many applications in order to share files between the applications.
+
+---
+
+## Sharing across AWS accounts
+To let an application in a different AWS account use this bucket, add that account's ID to `crossaccount_account_ids`. The application then connects through an `aws-s3-access-point` datastore in its own account.
+
+You grant trust **once per account, not once per application**. The consuming account creates and owns its own S3 access point, and decides which of its applications may use it. This bucket's policy simply delegates to any access point owned by a trusted account, so it never needs to change as applications come and go.
+
+The delegation statement matches on `s3:DataAccessPointAccount`. Because the account ID is fixed, the statement is **not** considered public, so `block_public_policy` remains enabled.
+
+### Limitations
+`crossaccount_account_ids` cannot be combined with `public_read_only`. A public bucket policy activates `RestrictPublicBuckets`, which blocks all cross-account access — including non-public delegation to specific accounts. Setting both fails at apply time rather than silently at runtime.
+
+**Encryption is not yet handled.** While `server_side_encryption` is on, this bucket uses the AWS-managed `aws/s3` KMS key, whose key policy is immutable. Objects encrypted with it **cannot be read from another account** under any configuration — the access point will be created successfully and listing will work, but every `GetObject` fails on decrypt. Until this module supports an encryption mode that works across accounts, cross-account sharing is only usable with `server_side_encryption = false`.

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ save and retrieve files without having to think about persistence. For more info
 | `public_read_only`        | boolean          | `false`    | If toggled on, the contents of this S3 bucket will be made publicly accessible. Public access will be read-only.                                                                                                                                           |
 | `cors_orgins`             | list(string)     | `[]`       | A set of origins that are allowed to make GET requests to this S3 bucket.                                                                                                                                                                                  |
 | `cors_methods`            | list(string)     | `["GET"]`  | A set of HTTP verbs that are allowed to be used when making CORS requests to this S3 bucket.                                                                                                                                                               |
-| `crossaccount_account_ids` | set(string)     | `[]`       | AWS account IDs allowed to reach this bucket through an S3 access point. See [Sharing across AWS accounts](#sharing-across-aws-accounts).                                                                                                                   |
+| `trusted_account_ids` | set(string)     | `[]`       | AWS account IDs allowed to reach this bucket through an S3 access point. See [Sharing across AWS accounts](#sharing-across-aws-accounts).                                                                                                                   |
 
 ## Outputs
 | Name                      | Description                                                                    |
@@ -56,13 +56,13 @@ This S3 bucket can be connected to many applications in order to share files bet
 ---
 
 ## Sharing across AWS accounts
-To let an application in a different AWS account use this bucket, add that account's ID to `crossaccount_account_ids`. The application then connects through an `aws-s3-access-point` datastore in its own account.
+To let an application in a different AWS account use this bucket, add that account's ID to `trusted_account_ids`. The application then connects through an `aws-s3-access-point` datastore in its own account.
 
 You grant trust **once per account, not once per application**. The consuming account creates and owns its own S3 access point, and decides which of its applications may use it. This bucket's policy simply delegates to any access point owned by a trusted account, so it never needs to change as applications come and go.
 
 The delegation statement matches on `s3:DataAccessPointAccount`. Because the account ID is fixed, the statement is **not** considered public, so `block_public_policy` remains enabled.
 
 ### Limitations
-`crossaccount_account_ids` cannot be combined with `public_read_only`. A public bucket policy activates `RestrictPublicBuckets`, which blocks all cross-account access — including non-public delegation to specific accounts. Setting both fails at apply time rather than silently at runtime.
+`trusted_account_ids` cannot be combined with `public_read_only`. A public bucket policy activates `RestrictPublicBuckets`, which blocks all cross-account access — including non-public delegation to specific accounts. Setting both fails at apply time rather than silently at runtime.
 
 **Encryption is not yet handled.** While `server_side_encryption` is on, this bucket uses the AWS-managed `aws/s3` KMS key, whose key policy is immutable. Objects encrypted with it **cannot be read from another account** under any configuration — the access point will be created successfully and listing will work, but every `GetObject` fails on decrypt. Until this module supports an encryption mode that works across accounts, cross-account sharing is only usable with `server_side_encryption = false`.

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ save and retrieve files without having to think about persistence. For more info
 | `public_read_only`        | boolean          | `false`    | If toggled on, the contents of this S3 bucket will be made publicly accessible. Public access will be read-only.                                                                                                                                           |
 | `cors_orgins`             | list(string)     | `[]`       | A set of origins that are allowed to make GET requests to this S3 bucket.                                                                                                                                                                                  |
 | `cors_methods`            | list(string)     | `["GET"]`  | A set of HTTP verbs that are allowed to be used when making CORS requests to this S3 bucket.                                                                                                                                                               |
-| `trusted_account_ids` | set(string)     | `[]`       | AWS account IDs allowed to reach this bucket through an S3 access point. See [Sharing across AWS accounts](#sharing-across-aws-accounts).                                                                                                                   |
+| `trusted_access_points` | list(object)   | `[]`       | AWS accounts allowed to reach this bucket through an S3 access point, each with an access level of `read` or `write`. See [Sharing across AWS accounts](#sharing-across-aws-accounts).                                                                       |
 
 ## Outputs
 | Name                      | Description                                                                    |
@@ -56,13 +56,24 @@ This S3 bucket can be connected to many applications in order to share files bet
 ---
 
 ## Sharing across AWS accounts
-To let an application in a different AWS account use this bucket, add that account's ID to `trusted_account_ids`. The application then connects through an `aws-s3-access-point` datastore in its own account.
+To let an application in a different AWS account use this bucket, add that account to `trusted_access_points` with the access level it should get. The application then connects through an `aws-s3-access-point` datastore in its own account.
+
+```hcl
+trusted_access_points = [
+  { account_id = "111122223333", access_level = "read" },
+  { account_id = "444455556666", access_level = "write" },
+]
+```
 
 You grant trust **once per account, not once per application**. The consuming account creates and owns its own S3 access point, and decides which of its applications may use it. This bucket's policy simply delegates to any access point owned by a trusted account, so it never needs to change as applications come and go.
 
-The delegation statement matches on `s3:DataAccessPointAccount`. Because the account ID is fixed, the statement is **not** considered public, so `block_public_policy` remains enabled.
+The level you set is a **ceiling**. The consuming account can narrow it further with its own access point policy or IAM policies, but it can never exceed what you grant here. `write` includes read.
+
+The delegation statements match on `s3:DataAccessPointAccount`. Because the account IDs are fixed, they are **not** considered public, so `block_public_policy` remains enabled.
+
+Accounts are grouped by level, so the bucket policy holds at most two delegation statements no matter how many accounts you list. That matters because bucket policies are capped at 20KB. Listing the same account at both levels is harmless — grants are additive, so it ends up with write.
 
 ### Limitations
-`trusted_account_ids` cannot be combined with `public_read_only`. A public bucket policy activates `RestrictPublicBuckets`, which blocks all cross-account access — including non-public delegation to specific accounts. Setting both fails at apply time rather than silently at runtime.
+`trusted_access_points` cannot be combined with `public_read_only`. A public bucket policy activates `RestrictPublicBuckets`, which blocks all cross-account access — including non-public delegation to specific accounts. Setting both fails at apply time rather than silently at runtime.
 
 **Encryption is not yet handled.** While `server_side_encryption` is on, this bucket uses the AWS-managed `aws/s3` KMS key, whose key policy is immutable. Objects encrypted with it **cannot be read from another account** under any configuration — the access point will be created successfully and listing will work, but every `GetObject` fails on decrypt. Until this module supports an encryption mode that works across accounts, cross-account sharing is only usable with `server_side_encryption = false`.

--- a/policy.tf
+++ b/policy.tf
@@ -1,19 +1,73 @@
-resource "aws_s3_bucket_policy" "public_read_only" {
-  count = var.public_read_only ? 1 : 0
-
-  bucket = aws_s3_bucket.this.id
-  policy = data.aws_iam_policy_document.public_read_only.json
+locals {
+  crossaccount_enabled = length(var.crossaccount_account_ids) > 0
+  needs_bucket_policy  = var.public_read_only || local.crossaccount_enabled
 }
 
-data "aws_iam_policy_document" "public_read_only" {
-  statement {
-    sid     = "PublicReadGetObject"
-    effect  = "Allow"
-    actions = ["s3:GetObject"]
-    principals {
-      identifiers = ["*"]
-      type        = "*"
+// A bucket has exactly one policy, so both the public-read statement and the cross-account
+// delegation have to live in the same document.
+moved {
+  from = aws_s3_bucket_policy.public_read_only
+  to   = aws_s3_bucket_policy.this
+}
+
+resource "aws_s3_bucket_policy" "this" {
+  count = local.needs_bucket_policy ? 1 : 0
+
+  bucket = aws_s3_bucket.this.id
+  policy = data.aws_iam_policy_document.this.json
+
+  lifecycle {
+    // A single public statement makes the entire document public, which activates
+    // RestrictPublicBuckets. That setting blocks all cross-account access -- including non-public
+    // delegation to specific accounts -- so these two features cannot coexist. It would otherwise
+    // fail silently at runtime rather than at apply time.
+    precondition {
+      condition     = !(var.public_read_only && local.crossaccount_enabled)
+      error_message = "public_read_only cannot be combined with crossaccount_account_ids. A public bucket policy activates RestrictPublicBuckets, which blocks the cross-account access point delegation."
     }
-    resources = ["${aws_s3_bucket.this.arn}/*"]
+  }
+}
+
+data "aws_iam_policy_document" "this" {
+  dynamic "statement" {
+    for_each = var.public_read_only ? [1] : []
+
+    content {
+      sid     = "PublicReadGetObject"
+      effect  = "Allow"
+      actions = ["s3:GetObject"]
+      principals {
+        identifiers = ["*"]
+        type        = "*"
+      }
+      resources = ["${aws_s3_bucket.this.arn}/*"]
+    }
+  }
+
+  // Delegates access control to access points owned by the trusted accounts. This is deliberately
+  // grant-agnostic: each consumer creates its own access point in its own account and controls
+  // which of its applications may use it, so this statement never changes per consumer.
+  //
+  // Conditioning on a fixed s3:DataAccessPointAccount keeps the statement non-public, so
+  // block_public_policy can stay enabled.
+  dynamic "statement" {
+    for_each = local.crossaccount_enabled ? [1] : []
+
+    content {
+      sid     = "DelegateToCrossAccountAccessPoints"
+      effect  = "Allow"
+      actions = ["s3:*"]
+      principals {
+        identifiers = ["*"]
+        type        = "AWS"
+      }
+      resources = [aws_s3_bucket.this.arn, "${aws_s3_bucket.this.arn}/*"]
+
+      condition {
+        test     = "StringEquals"
+        variable = "s3:DataAccessPointAccount"
+        values   = tolist(var.crossaccount_account_ids)
+      }
+    }
   }
 }

--- a/policy.tf
+++ b/policy.tf
@@ -17,10 +17,9 @@ resource "aws_s3_bucket_policy" "this" {
   policy = data.aws_iam_policy_document.this.json
 
   lifecycle {
-    // A single public statement makes the entire document public, which activates
-    // RestrictPublicBuckets. That setting blocks all cross-account access -- including non-public
-    // delegation to specific accounts -- so these two features cannot coexist. It would otherwise
-    // fail silently at runtime rather than at apply time.
+    // A single public statement makes the entire document public, which activates RestrictPublicBuckets.
+    // That setting blocks all cross-account access, including non-public delegation to specific accounts, so these two features cannot coexist.
+    // It would otherwise fail silently at runtime rather than at apply time.
     precondition {
       condition     = !(var.public_read_only && local.crossaccount_enabled)
       error_message = "public_read_only cannot be combined with trusted_account_ids. A public bucket policy activates RestrictPublicBuckets, which blocks the cross-account access point delegation."

--- a/policy.tf
+++ b/policy.tf
@@ -1,6 +1,36 @@
 locals {
-  crossaccount_enabled = length(var.trusted_account_ids) > 0
+  crossaccount_enabled = length(var.trusted_access_points) > 0
   needs_bucket_policy  = var.public_read_only || local.crossaccount_enabled
+
+  // Grouped by access level so the document holds at most one statement per level rather than one
+  // per account. Bucket policies are capped at 20KB.
+  trusted_read_account_ids  = distinct([for ap in var.trusted_access_points : ap.account_id if ap.access_level == "read"])
+  trusted_write_account_ids = distinct([for ap in var.trusted_access_points : ap.account_id if ap.access_level == "write"])
+
+  crossaccount_read_actions = [
+    "s3:GetBucketLocation",
+    "s3:GetObject",
+    "s3:GetObjectTagging",
+    "s3:GetObjectVersion",
+    "s3:GetObjectVersionTagging",
+    "s3:ListBucket",
+    "s3:ListBucketVersions",
+  ]
+
+  // Write is a superset of read. An account granted write can still be narrowed to less by its own
+  // access point policy, but it can never exceed what is granted here.
+  crossaccount_write_actions = concat(local.crossaccount_read_actions, [
+    "s3:AbortMultipartUpload",
+    "s3:DeleteObject",
+    "s3:DeleteObjectTagging",
+    "s3:DeleteObjectVersion",
+    "s3:DeleteObjectVersionTagging",
+    "s3:ListBucketMultipartUploads",
+    "s3:ListMultipartUploadParts",
+    "s3:PutObject",
+    "s3:PutObjectTagging",
+    "s3:PutObjectVersionTagging",
+  ])
 }
 
 // A bucket has exactly one policy, so both the public-read statement and the cross-account
@@ -22,7 +52,7 @@ resource "aws_s3_bucket_policy" "this" {
     // It would otherwise fail silently at runtime rather than at apply time.
     precondition {
       condition     = !(var.public_read_only && local.crossaccount_enabled)
-      error_message = "public_read_only cannot be combined with trusted_account_ids. A public bucket policy activates RestrictPublicBuckets, which blocks the cross-account access point delegation."
+      error_message = "public_read_only cannot be combined with trusted_access_points. A public bucket policy activates RestrictPublicBuckets, which blocks the cross-account access point delegation."
     }
   }
 }
@@ -45,17 +75,17 @@ data "aws_iam_policy_document" "this" {
 
   // Delegates access control to access points owned by the trusted accounts. This is deliberately
   // grant-agnostic: each consumer creates its own access point in its own account and controls
-  // which of its applications may use it, so this statement never changes per consumer.
+  // which of its applications may use it, so these statements never change per consumer.
   //
-  // Conditioning on a fixed s3:DataAccessPointAccount keeps the statement non-public, so
+  // Conditioning on a fixed s3:DataAccessPointAccount keeps the statements non-public, so
   // block_public_policy can stay enabled.
   dynamic "statement" {
-    for_each = local.crossaccount_enabled ? [1] : []
+    for_each = length(local.trusted_read_account_ids) > 0 ? [local.trusted_read_account_ids] : []
 
     content {
-      sid     = "DelegateToCrossAccountAccessPoints"
+      sid     = "DelegateReadToTrustedAccessPoints"
       effect  = "Allow"
-      actions = ["s3:*"]
+      actions = local.crossaccount_read_actions
       principals {
         identifiers = ["*"]
         type        = "AWS"
@@ -65,7 +95,28 @@ data "aws_iam_policy_document" "this" {
       condition {
         test     = "StringEquals"
         variable = "s3:DataAccessPointAccount"
-        values   = tolist(var.trusted_account_ids)
+        values   = statement.value
+      }
+    }
+  }
+
+  dynamic "statement" {
+    for_each = length(local.trusted_write_account_ids) > 0 ? [local.trusted_write_account_ids] : []
+
+    content {
+      sid     = "DelegateWriteToTrustedAccessPoints"
+      effect  = "Allow"
+      actions = local.crossaccount_write_actions
+      principals {
+        identifiers = ["*"]
+        type        = "AWS"
+      }
+      resources = [aws_s3_bucket.this.arn, "${aws_s3_bucket.this.arn}/*"]
+
+      condition {
+        test     = "StringEquals"
+        variable = "s3:DataAccessPointAccount"
+        values   = statement.value
       }
     }
   }

--- a/policy.tf
+++ b/policy.tf
@@ -1,5 +1,5 @@
 locals {
-  crossaccount_enabled = length(var.crossaccount_account_ids) > 0
+  crossaccount_enabled = length(var.trusted_account_ids) > 0
   needs_bucket_policy  = var.public_read_only || local.crossaccount_enabled
 }
 
@@ -23,7 +23,7 @@ resource "aws_s3_bucket_policy" "this" {
     // fail silently at runtime rather than at apply time.
     precondition {
       condition     = !(var.public_read_only && local.crossaccount_enabled)
-      error_message = "public_read_only cannot be combined with crossaccount_account_ids. A public bucket policy activates RestrictPublicBuckets, which blocks the cross-account access point delegation."
+      error_message = "public_read_only cannot be combined with trusted_account_ids. A public bucket policy activates RestrictPublicBuckets, which blocks the cross-account access point delegation."
     }
   }
 }
@@ -66,7 +66,7 @@ data "aws_iam_policy_document" "this" {
       condition {
         test     = "StringEquals"
         variable = "s3:DataAccessPointAccount"
-        values   = tolist(var.crossaccount_account_ids)
+        values   = tolist(var.trusted_account_ids)
       }
     }
   }

--- a/variables.tf
+++ b/variables.tf
@@ -48,7 +48,7 @@ This is optional and only used if you also specify cors_origins.
 EOF
 }
 
-variable "crossaccount_account_ids" {
+variable "trusted_account_ids" {
   type        = set(string)
   default     = []
   description = <<EOF

--- a/variables.tf
+++ b/variables.tf
@@ -48,12 +48,27 @@ This is optional and only used if you also specify cors_origins.
 EOF
 }
 
-variable "trusted_account_ids" {
-  type        = set(string)
+variable "trusted_access_points" {
+  type = list(object({
+    account_id   = string
+    access_level = string
+  }))
   default     = []
   description = <<EOF
-A set of AWS account IDs that are allowed to reach this bucket through an S3 access point.
+A list of AWS accounts allowed to reach this bucket through an S3 access point, and how much access each one gets.
+`account_id` is a 12-digit AWS account ID. `access_level` is either "read" or "write", where "write" also includes read.
 Each listed account creates and owns its own access point, and decides which of its applications may use it, so you grant trust once per account, not once per application.
+The level you grant here is a ceiling: the consuming account can narrow it further with its own access point policy, but it can never widen it.
 This cannot be combined with public_read_only because a public bucket policy activates RestrictPublicBuckets, which blocks all cross-account access.
 EOF
+
+  validation {
+    condition     = alltrue([for ap in var.trusted_access_points : contains(["read", "write"], ap.access_level)])
+    error_message = "access_level must be either \"read\" or \"write\"."
+  }
+
+  validation {
+    condition     = alltrue([for ap in var.trusted_access_points : can(regex("^[0-9]{12}$", ap.account_id))])
+    error_message = "account_id must be a 12-digit AWS account ID."
+  }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -53,9 +53,7 @@ variable "trusted_account_ids" {
   default     = []
   description = <<EOF
 A set of AWS account IDs that are allowed to reach this bucket through an S3 access point.
-Each listed account creates and owns its own access point, and decides which of its applications may
-use it -- so you grant trust once per account, not once per application.
-This cannot be combined with public_read_only: a public bucket policy activates RestrictPublicBuckets,
-which blocks all cross-account access.
+Each listed account creates and owns its own access point, and decides which of its applications may use it, so you grant trust once per account, not once per application.
+This cannot be combined with public_read_only because a public bucket policy activates RestrictPublicBuckets, which blocks all cross-account access.
 EOF
 }

--- a/variables.tf
+++ b/variables.tf
@@ -47,3 +47,15 @@ A set of HTTP verbs that are allowed to be used when making CORS requests to thi
 This is optional and only used if you also specify cors_origins.
 EOF
 }
+
+variable "crossaccount_account_ids" {
+  type        = set(string)
+  default     = []
+  description = <<EOF
+A set of AWS account IDs that are allowed to reach this bucket through an S3 access point.
+Each listed account creates and owns its own access point, and decides which of its applications may
+use it -- so you grant trust once per account, not once per application.
+This cannot be combined with public_read_only: a public bucket policy activates RestrictPublicBuckets,
+which blocks all cross-account access.
+EOF
+}


### PR DESCRIPTION
Added support for enabling IAM access to an s3 bucket across aws accounts using s3 access points.